### PR TITLE
Add capability to post to Discord channels using webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a simple script to get the latest papers from astro-ph/arxiv,
 search their abstracts and titles for keywords, and report the
 results.  Reports are done either through e-mail or by posting to
-slack channels using web-hooks.  This way if we forget to read
+slack/discord channels using web-hooks.  This way if we forget to read
 astro-ph for a bit, we can atleast get notified of the papers deemed
 important to us (and discuss them on slack).
 
@@ -12,7 +12,7 @@ Note: this requires python 3
 ## usage
 
 ```
-./lazy_astroph.py [-m e-mail-address] [-w slack-webhook-file] inputs
+./lazy_astroph.py [-m e-mail-address] [-w webhook-file] inputs
 ```
 
 where `inputs` is a file of (case-insensitive) keywords, one per
@@ -36,13 +36,15 @@ they don't also contain "dark energy", "interstellar medium", or
 "supernova" (since `"nova" in "supernova"` is `True` in python).
 And it will return those papers containing xrb.
 
-Slack channels are indicated by a line beginning with "#", with
-an optional "requires=N", where N is the number of keywords
-we must match before posting a paper to a slack channel.
+Slack/Discord channels are indicated by a line beginning with "#",
+with an optional "requires=N", where N is the number of keywords
+we must match before posting a paper to a channel.
+Discord channels must be specified using their channel ID, not
+the channel name.
 
-You need to create a webhook via slack.  Put the URL into a file
-(just the URL, nothing else) and then pass the name of that
-file into `lazy_astroph.py` using the `-w` parameter.
+You need to create a webhook via slack or discord.  Put the URL
+into a file (just the URLs, nothing else) and then pass the name
+of that file into `lazy_astroph.py` using the `-w` parameter.
 
 
 ## automating

--- a/inputs.discord
+++ b/inputs.discord
@@ -1,0 +1,102 @@
+#1316121062886608957 require=2 
+SNIa
+SN Ia
+SNe Ia
+supernova               NOT: dark energy, interstellar medium, ISM, redshift, cosmic microwave, CMB, cosmology, cosmologies, ccsn, core-collapse
+type Ia supernova
+Chandrasekhar
+degenerate              NOT: CMB, lensing, doped
+white dwarf
+flame
+deflagration
+detonation
+helium detonation
+thermonuclear
+double degenerate
+WD merger
+
+#1316522331224670228 require=2 
+CCSN
+CCSNe
+supernova               NOT: dark energy, interstellar medium, ISM, redshift, cosmic microwave, CMB, cosmology, cosmologies, thermonuclear
+progenitor              NOT: asteroid, basaltic, jupiter, white dwarf
+core-collapse
+central engine
+explosion mechanism
+spectral neutrino
+neutrino transport
+radiation hydrodynamics NOT: photon
+gravitational collapse
+proto-neutron star
+proto neutron star
+PNS
+hypernova
+hypernovae
+SASI
+accretion shock
+
+#1316583710229008460 require=2
+hydro                   NOT: galaxy, galaxies, cosmology, large scale structure, large-scale structure, dust, cloud, interstellar medium, ISM, interstellar, jets, hydrogen, hydrostatic, Lyman
+flash
+flash-x
+castro
+maestro
+fornax
+athena
+gr1d
+asterx
+gram-x
+magnetohydrodynamics
+MHD
+GRMHD
+adaptive mesh refinement
+AMR
+radiation hydrodynamics
+turbulence              NOT: cluster, interstellar, cloud, galactic, nebula, adaptive optics, seeing, guide star, molecular, disks, dust
+shock
+discontinuous galerkin
+reconstruction
+riemann
+
+#1316872902934663238 require=2
+microphysics
+nuclear equation of state
+thornado
+weaklib
+nulib
+stellarcollapse
+xnet
+winnet
+skynet
+torch                   NOT: pytorch
+reaclib
+reaction network
+nuclear burning
+reaction kinetics
+qse
+neutrino opacity
+neutrino opacities
+tabulated
+
+#1316869734381260887 require=2
+hpc
+gpu
+computational cost
+performance portability
+roofline model
+CUDA
+kokkos
+raja
+openacc
+openmp offload
+openmp target
+risc-v
+neural network
+machine learning
+artificial intelligence
+pytorch
+
+
+
+
+


### PR DESCRIPTION
This PR generalizes the webhook interface to also support Discord.

Adds arguments `--slack_api` and `--discord_api` to control which API is used.
Based on this, the script will either use `slack_post` or `discord_post`.
Backwards compatibility should be maintained (`slack_api = True` by default when `-w` specified), but was not able to test this with a Slack workspace.

To use the Discord API requires two changes to the workflow:
* The `inputs` file must specify the channel ID instead of the channel name
* The webhooks file must contain a list of webhook URLs for each channel (order doesn't matter). This is because Discord doesn't allow a single webhook for the entire server.